### PR TITLE
[IMP] catch wheel volume change on a bigger space

### DIFF
--- a/app/views/playerControlsExtended.js
+++ b/app/views/playerControlsExtended.js
@@ -8,6 +8,7 @@ const ControlsExtended = Mn.ItemView.extend({
 
     ui: {
         volumeBar: '#volume-bar',
+        controlsArea: '#controls-area',
         shuffle: '#shuffle',
         repeat: '#repeat',
         speaker: '#speaker'
@@ -15,7 +16,7 @@ const ControlsExtended = Mn.ItemView.extend({
 
     events: {
         'mousedown @ui.volumeBar': 'changeVol',
-        'wheel @ui.volumeBar': 'changeVolWheel',
+        'wheel @ui.controlsArea': 'changeVolWheel',
         'click @ui.shuffle': 'toggleShuffle',
         'click @ui.repeat': 'toggleRepeat',
         'click @ui.speaker': 'toggleVolume'

--- a/app/views/templates/app_layout.jst
+++ b/app/views/templates/app_layout.jst
@@ -4,7 +4,7 @@
 	<div class="player" aria-expanded="false">
 	    <div class="play-controls"></div>
 	    <div class="timeline"></div>
-	    <div class="controls-extended"></div>
+	    <div class="controls-extended" id='controls-area'></div>
 	</div>
 </main>
 <div role="dialog"></div>


### PR DESCRIPTION
with the recent change, it is possible to increase/decrease the volume with the mouse wheel, but only on the volume-bar (which is very thin and that makes it a bit difficult to use). Defining a bigger area for catching this mouse wheel would be much user friendly.